### PR TITLE
Removed deprecated CertificateThumbprint parameters

### DIFF
--- a/ProtectedData.Tests.ps1
+++ b/ProtectedData.Tests.ps1
@@ -172,36 +172,6 @@ Describe 'Certificate-based encryption and decryption (By thumbprint)' {
         }
     }
 
-    Context 'Legacy CertificateThumbprint parameter' {
-        Mock Write-Warning -ModuleName ProtectedData { }
-
-        $hash = @{}
-
-        It 'Encrypts data with the -CertificateThumbprint parameter' {
-            {$hash['Protected'] = Protect-Data -InputObject $stringToEncrypt -CertificateThumbprint $certThumbprint -SkipCertificateVerification} |
-            Should Not Throw
-        }
-
-        It 'Decrypts data with the -CertificateThumbprint parameter' {
-            Unprotect-Data -InputObject $hash['Protected'] -CertificateThumbprint $certThumbprint -SkipCertificateVerification |
-            Should Be $stringToEncrypt
-        }
-
-        It 'Adds a new thumbprint' {
-            { Add-ProtectedDataCredential -InputObject $hash['Protected'] -CertificateThumbprint $certThumbprint -NewCertificateThumbprint $secondCertThumbprint -SkipCertificateVerification } |
-            Should Not Throw
-        }
-
-        It 'Decrypts data with the new thumbprint' {
-            Unprotect-Data -InputObject $hash['Protected'] -CertificateThumbprint $secondCertThumbprint -SkipCertificateVerification |
-            Should Be $stringToEncrypt
-        }
-
-        It 'Warns the user of the deprecated parameters' {
-            Assert-MockCalled Write-Warning -ModuleName ProtectedData -ParameterFilter { $Message -match '.*The -(New)?CertificateThumbprint parameter is now deprecated.*' }
-        }
-    }
-
     Context 'General Usage' {
         It 'Produces an error if a self-signed certificate is used, without the -SkipCertificateVerification switch' {
             { $null = Protect-Data -InputObject $stringToEncrypt -Certificate $certThumbprint -ErrorAction Stop } | Should Throw

--- a/ProtectedData.psd1
+++ b/ProtectedData.psd1
@@ -8,7 +8,7 @@
 
 @{
     ModuleToProcess        = 'ProtectedData.psm1'
-    ModuleVersion          = '2.1'
+    ModuleVersion          = '3.0'
     GUID                   = 'fc6a2f6a-563d-422a-85b5-9638e45a370e'
     Author                 = 'Dave Wyatt'
     CompanyName            = 'Home'
@@ -19,9 +19,6 @@
     FunctionsToExport      = 'Protect-Data', 'Unprotect-Data', 'Get-ProtectedDataSupportedTypes',
                              'Add-ProtectedDataCredential', 'Remove-ProtectedDataCredential',
                              'Get-KeyEncryptionCertificate'
-    CmdletsToExport        = '*'
-    VariablesToExport      = '*'
-    AliasesToExport        = '*'
 
     PrivateData = @{
         PSData = @{
@@ -39,6 +36,8 @@
 
             # Indicates this is a pre-release/testing version of the module.
             IsPrerelease = 'False'
+
+            ReleaseNotes = 'Removed deprecated CertificateThumbprint parameters in favor of using Certificate'
         }
     }
 }


### PR DESCRIPTION
Aside from removing the parameters that were deprecated in version v2.1, there are no functional changes here.  Users can use v2.1 with existing scripts, and upgrade to v3.0 once they've replaced instances of `-CertificateThumbprint` with `-Certificate` (with the exception of the `Get-KeyEncryptionCertificate` command.)
